### PR TITLE
One hour disconnect crash

### DIFF
--- a/src/Bitfinex.Client.Websocket/Websockets/BitfinexWebsocketCommunicator.cs
+++ b/src/Bitfinex.Client.Websocket/Websockets/BitfinexWebsocketCommunicator.cs
@@ -138,9 +138,9 @@ namespace Bitfinex.Client.Websocket.Websockets
             var diffMin = Math.Abs(DateTime.UtcNow.Subtract(_lastReceivedMsg).TotalMinutes);
             if(diffMin > 1)
                 Log.Information(L($"Last message received {diffMin} min ago"));
-            if (diffMin > 10)
+            if (diffMin > 2)
             {
-                Log.Information(L("Last message received more than 10 min ago. Hard restart.."));
+                Log.Information(L("Last message received more than 2 min ago. Hard restart.."));
 
                 _client?.Abort();
                 _client?.Dispose();

--- a/src/Bitfinex.Client.Websocket/Websockets/BitfinexWebsocketCommunicator.cs
+++ b/src/Bitfinex.Client.Websocket/Websockets/BitfinexWebsocketCommunicator.cs
@@ -143,6 +143,8 @@ namespace Bitfinex.Client.Websocket.Websockets
                 Log.Information(L("Last message received more than 10 min ago. Hard restart.."));
 
                 _client?.Abort();
+                _client?.Dispose();
+                _client = null;
                 await Reconnect();
             }
         }


### PR DESCRIPTION
Hello Marfusios,
Thanks for sharing your bitfinex websocket library!

I encountered an error after roughly 1 hour of being connected to bitfinex:

2018-01-17 15:18:28 INF [BFX WEBSOCKET COMMUNICATOR] Reconnecting...
2018-01-17 15:18:28 ERR [BFX WEBSOCKET COMMUNICATOR] Exception while connecting
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.WebSockets.ClientWebSocket'.
   at System.Net.WebSockets.ClientWebSocket.ConnectAsync(Uri uri, CancellationToken cancellationToken)
   at Bitfinex.Client.Websocket.Websockets.BitfinexWebsocketCommunicator.<StartClient>d__13.MoveNext()

I made the changes below to try and counter this, and they appear to be working so far!

I also changed the watchdog timer to much lower, as the spec says that it will send a heartbeat every 1 minute - so i thought, if it hasn't received one in 2 minutes, the connection is probably fatties leg.

Cheers,
Matt