### PR TITLE
Subscriptions persist across reconnects &simplified client/communicator

### DIFF
--- a/src/Bitfinex.Client.Websocket/Websockets/BitfinexWebsocketCommunicator.cs
+++ b/src/Bitfinex.Client.Websocket/Websockets/BitfinexWebsocketCommunicator.cs
@@ -1,11 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.WebSockets;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Bitfinex.Client.Websocket.Json;
+using Bitfinex.Client.Websocket.Requests;
 using Bitfinex.Client.Websocket.Validations;
+using Newtonsoft.Json;
 using Serilog;
 
 namespace Bitfinex.Client.Websocket.Websockets
@@ -21,6 +26,8 @@ namespace Bitfinex.Client.Websocket.Websockets
         private bool _disposing = false;
         private ClientWebSocket _client;
         private CancellationTokenSource _cancelation;
+        
+        private List<SubscribeRequestBase> _storedSubscriptions;        
 
         private readonly Subject<string> _messageReceivedSubject = new Subject<string>();
 
@@ -39,6 +46,8 @@ namespace Bitfinex.Client.Websocket.Websockets
 
             var minute = 1000 * 60;
             _lastChanceTimer = new Timer(async x => await LastChance(x), null, minute, minute);
+
+            _storedSubscriptions = new List<SubscribeRequestBase>();
         }
 
         public void Dispose()
@@ -60,7 +69,7 @@ namespace Bitfinex.Client.Websocket.Websockets
             return StartClient(_url, _cancelation.Token);
         }
 
-        public async Task Send(string message)
+        public async Task SendInternal(string message)
         {
             BfxValidations.ValidateInput(message, nameof(message));
 
@@ -70,6 +79,23 @@ namespace Bitfinex.Client.Websocket.Websockets
             var client = await GetClient();
             await client.SendAsync(messageSegment, WebSocketMessageType.Text, true, _cancelation.Token);
         }
+
+        public Task Send<T>(T request)
+        {
+            BfxValidations.ValidateInput(request, nameof(request));
+
+            //Store subscriptions to re-establish if communication is lost and re-established
+            if(request is SubscribeRequestBase)
+            {
+                _storedSubscriptions.Add(request as SubscribeRequestBase);
+            }
+
+            var serialized = JsonConvert.SerializeObject(request, BitfinexJsonSerializer.Settings);
+            return this.SendInternal(serialized);
+        }
+
+
+      
 
         private async Task StartClient(Uri uri, CancellationToken token)
         {
@@ -109,6 +135,16 @@ namespace Bitfinex.Client.Websocket.Websockets
 
             _cancelation = new CancellationTokenSource();
             await StartClient(_url, _cancelation.Token);
+
+            List<Task> resubscribeTasks = new List<Task>();
+
+            Log.Information(L("Re-subscribing..."));
+
+            _storedSubscriptions.Select(sub=> this.Send(sub)).ToArray();
+
+            Task.WaitAll(resubscribeTasks.ToArray());
+
+            Log.Information(L($"Resent {_storedSubscriptions.Count} subscriptions"));
         }
 
         private async Task Listen(ClientWebSocket client, CancellationToken token)

--- a/test_integration/Bitfinex.Client.Websocket.Sample/Program.cs
+++ b/test_integration/Bitfinex.Client.Websocket.Sample/Program.cs
@@ -39,78 +39,75 @@ namespace Bitfinex.Client.Websocket.Sample
             Log.Debug("              STARTING              ");
             Log.Debug("====================================");
 
-
-            var url = BitfinexValues.ApiWebsocketUrl;
-            using (var communicator = new BitfinexWebsocketCommunicator(url))
+            
+            using (var client = new BitfinexWebsocketClient())
             {
-                using (var client = new BitfinexWebsocketClient(communicator))
+
+                client.Streams.PongStream.Subscribe(pong => Log.Information($"Pong received! Id: {pong.Cid}"));
+                client.Streams.TickerStream.Subscribe(ticker =>
+                    Log.Information($"{ticker.Pair} - last price: {ticker.LastPrice}, bid: {ticker.Bid}, ask: {ticker.Ask}"));
+                client.Streams.TradesStream.Where(x => x.Type == TradeType.Executed).Subscribe(x =>
+                    Log.Information($"Trade {x.Pair} executed. Time: {x.Mts:mm:ss.fff}, Amount: {x.Amount}, Price: {x.Price}"));
+
+                client.Streams.CandlesStream.Subscribe(candles =>
                 {
-                    
-                    client.Streams.PongStream.Subscribe(pong => Log.Information($"Pong received! Id: {pong.Cid}"));
-                    client.Streams.TickerStream.Subscribe(ticker => 
-                        Log.Information($"{ticker.Pair} - last price: {ticker.LastPrice}, bid: {ticker.Bid}, ask: {ticker.Ask}"));
-                    client.Streams.TradesStream.Where(x => x.Type == TradeType.Executed).Subscribe(x => 
-                        Log.Information($"Trade {x.Pair} executed. Time: {x.Mts:mm:ss.fff}, Amount: {x.Amount}, Price: {x.Price}"));
-
-                    client.Streams.CandlesStream.Subscribe(candles =>
+                    candles.CandleList.OrderBy(x => x.Mts).ToList().ForEach(x =>
                     {
-                        candles.CandleList.OrderBy(x => x.Mts).ToList().ForEach(x =>
-                        {
-                            Log.Information(
-                                $"Candle(Pair : {candles.Pair} TimeFrame : {candles.TimeFrame.GetStringValue()}) --> {x.Mts} High : {x.High} Low : {x.Low} Open : {x.Open} Close : {x.Close}");
-                        });
-                    });
-
-                    client.Streams.BookStream.Subscribe(book =>
                         Log.Information(
-                            $"Book | channel: {book.ChanId} pair: {book.Pair}, price: {book.Price}, amount {book.Amount}, count: {book.Count}"));
-
-                    client.Streams.CandlesStream.Subscribe(candles =>
-                    {
-                        candles.CandleList.OrderBy(x => x.Mts).ToList().ForEach(x =>
-                        {
-                            Log.Information(
-                                $"Candle(Pair : {candles.Pair} TimeFrame : {candles.TimeFrame.GetStringValue()}) --> {x.Mts} High : {x.High} Low : {x.Low} Open : {x.Open} Close : {x.Close}");
-                        });
+                            $"Candle(Pair : {candles.Pair} TimeFrame : {candles.TimeFrame.GetStringValue()}) --> {x.Mts} High : {x.High} Low : {x.Low} Open : {x.Open} Close : {x.Close}");
                     });
+                });
 
-                    client.Streams.AuthenticationStream.Subscribe(auth => Log.Information($"Authenticated: {auth.IsAuthenticated}"));
-                    client.Streams.WalletStream
-                        .Subscribe(wallet =>
-                            Log.Information($"Wallet {wallet.Currency} balance: {wallet.Balance} type: {wallet.Type}"));
+                client.Streams.BookStream.Subscribe(book =>
+                    Log.Information(
+                        $"Book | channel: {book.ChanId} pair: {book.Pair}, price: {book.Price}, amount {book.Amount}, count: {book.Count}"));
 
-                    communicator.Start().Wait();
-
-                    client.Send(new PingRequest() { Cid = 123456 });
-
-                    client.Send(new TickerSubscribeRequest("BTC/USD"));
-                    client.Send(new TickerSubscribeRequest("ETH/USD"));
-
-                    //client.Send(new TradesSubscribeRequest("ETH/USD"));
-
-                    client.Send(new CandlesSubscribeRequest("BTC/USD", BitfinexTimeFrame.OneMinute));
-                    client.Send(new CandlesSubscribeRequest("ETH/USD", BitfinexTimeFrame.OneMinute));
-
-                    //client.Send(new BookSubscribeRequest("BTC/USD", BitfinexPrecision.P0, BitfinexFrequency.TwoSecDelay));
-                    //client.Send(new BookSubscribeRequest("BTC/USD", BitfinexPrecision.P3, BitfinexFrequency.Realtime));
-
-                    if (!string.IsNullOrWhiteSpace(API_SECRET))
+                client.Streams.CandlesStream.Subscribe(candles =>
+                {
+                    candles.CandleList.OrderBy(x => x.Mts).ToList().ForEach(x =>
                     {
-                        client.Authenticate(API_KEY, API_SECRET);
+                        Log.Information(
+                            $"Candle(Pair : {candles.Pair} TimeFrame : {candles.TimeFrame.GetStringValue()}) --> {x.Mts} High : {x.High} Low : {x.Low} Open : {x.Open} Close : {x.Close}");
+                    });
+                });
 
-                        // Place BUY order
-                        // client.Send(new NewOrderRequest(33, 1, "ETH/USD", OrderType.ExchangeLimit, 0.2, 100));
+                client.Streams.AuthenticationStream.Subscribe(auth => Log.Information($"Authenticated: {auth.IsAuthenticated}"));
+                client.Streams.WalletStream
+                    .Subscribe(wallet =>
+                        Log.Information($"Wallet {wallet.Currency} balance: {wallet.Balance} type: {wallet.Type}"));
 
-                        // Place SELL order
-                        // client.Send(new NewOrderRequest(33, 2, "ETH/USD", OrderType.ExchangeLimit, -0.2, 2000));
+                client.Start().Wait();
 
-                        // Cancel order
-                        // client.Send(new CancelOrderRequest(1));
-                    }
+                client.Ping(123456);
 
-                    ExitEvent.WaitOne();
+
+                client.SubscribeTicker("ETH/USD");
+
+                //client.Send(new TradesSubscribeRequest("ETH/USD"));
+
+                client.SubscribeCandle("BTC/USD", BitfinexTimeFrame.OneMinute);
+                client.SubscribeCandle("ETH/USD", BitfinexTimeFrame.OneMinute);
+
+                //client.Send(new BookSubscribeRequest("BTC/USD", BitfinexPrecision.P0, BitfinexFrequency.TwoSecDelay));
+                //client.Send(new BookSubscribeRequest("BTC/USD", BitfinexPrecision.P3, BitfinexFrequency.Realtime));
+
+                if (!string.IsNullOrWhiteSpace(API_SECRET))
+                {
+                    client.Authenticate(API_KEY, API_SECRET);
+
+                    // Place BUY order
+                    // client.Send(new NewOrderRequest(33, 1, "ETH/USD", OrderType.ExchangeLimit, 0.2, 100));
+
+                    // Place SELL order
+                    // client.Send(new NewOrderRequest(33, 2, "ETH/USD", OrderType.ExchangeLimit, -0.2, 2000));
+
+                    // Cancel order
+                    // client.Send(new CancelOrderRequest(1));
                 }
+
+                ExitEvent.WaitOne();
             }
+
 
             Log.Debug("====================================");
             Log.Debug("              STOPPING              ");


### PR DESCRIPTION
Hello Marfusios,

I had trouble with subscriptions being lost after a reconnect - In this PR i made it the communicators responsibility to re-send subscriptions in reconnect - this prompted me to also change the surface of the client - not sure if you like this way of doing things, but it seemed to make things cleaner in my head.

Cheers,
Matt