### PR TITLE
Fix exception when parsing notifications containing text

### DIFF
--- a/src/Bitfinex.Client.Websocket/Responses/Notifications/NotificationConverter.cs
+++ b/src/Bitfinex.Client.Websocket/Responses/Notifications/NotificationConverter.cs
@@ -39,7 +39,7 @@ namespace Bitfinex.Client.Websocket.Responses.Notifications
                 NotifyInfo = array[4].ToString(),
                 Code = (long?) array[5],
                 Status = (string) array[6],
-                Text = (string) array[7],
+                Text = array[7].ToString(),
             };
         }
 


### PR DESCRIPTION
Found this when trying to place an order just after the maintenance period last week.

Fixes:

```
System.ArgumentException: Can not convert Object to String.
   at Newtonsoft.Json.Linq.JToken.op_Explicit(JToken value)
   at Bitfinex.Client.Websocket.Responses.Notifications.NotificationConverter.JArrayToNotification(JArray array)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.Linq.JToken.ToObject(Type objectType, JsonSerializer jsonSerializer)
   at Newtonsoft.Json.Linq.JToken.ToObject(Type objectType)
   at Newtonsoft.Json.Linq.JToken.ToObject[T]()
   at Bitfinex.Client.Websocket.Responses.Notifications.Notification.Handle(JToken token, Subject`1 subject)
   at Bitfinex.Client.Websocket.Client.BitfinexAuthenticatedHandler.HandleAccountInfo(JToken token, ConfigurationState config)
   at Bitfinex.Client.Websocket.Client.BitfinexWebsocketClient.OnArrayMessage(String msg)
   at Bitfinex.Client.Websocket.Client.BitfinexWebsocketClient.HandleMessage(ResponseMessage message)
```

When receiving a notification for an order containing text like this: 
```
[0,"n",[1564662936986,"on-req",null,null,[null,null,null,"tBTCUSD",null,null,0.1,null,"LIMIT",null,null,null,0,null,null,null,8000,null,0,0,null,null,null,0,null,null,null,null,null,null,null,null],null,"ERROR",{"error":"action: disabled"}]]
```